### PR TITLE
Add manual workflow trigger

### DIFF
--- a/.github/workflows/distribute-apps.yml
+++ b/.github/workflows/distribute-apps.yml
@@ -8,6 +8,14 @@ on:
         type: string
         description: 'Either development or production'
 
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: 'Either development or production'
+
 jobs:
   distribute-ios:
     runs-on: macos-14


### PR DESCRIPTION
 the previous on/trigger, `workflow_call`, allows this action to be run by other pipelines.

This new one `workflow_dispatch` allows for it to be called manually


docs https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch