### PR TITLE
update release signingConfig - can now build debug without `release.keystore`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,10 +12,6 @@ project.ext.envConfigFiles = [
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
-def keystorePropertiesFile = project(':app').file("play_store_keys/release_keystore.properties");
-def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-
 static def getNumberOfGitCommtis() {
     def result = "git rev-list HEAD --count".execute().text.trim() //unix
     if (result.empty) result = "PowerShell -Command git rev-list HEAD --count".execute().text.trim() //windows
@@ -116,10 +112,15 @@ android {
             keyPassword 'android'
         }
         release {
-            storeFile file(keystoreProperties['storeFileName'])
-            storePassword keystoreProperties['storePassword']
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
+            def keystorePropertiesFile = project(':app').file("play_store_keys/release_keystore.properties")
+            def keystoreProperties = new Properties()
+            if(keystorePropertiesFile.exists()) {
+                keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+                storeFile file(keystoreProperties['storeFileName'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
         }
     }
     buildTypes {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ios:testflight:distribute": "bundle exec fastlane ios testflight_distribute",
     "ios:setup": "bundle exec fastlane ios setup_profiles_certs",
     "android:debug:dev": "ENVFILE=.env.development react-native run-android --mode DevelopmentDebug --appIdSuffix=development",
-    "android:release:dev": "ENVFILE=.env.development react-native run-android --mode DevelopmentRelease --appIdSuffix=development ",
+    "android:release:dev": "ENVFILE=.env.development react-native run-android --mode DevelopmentRelease --appIdSuffix=development",
     "android:debug:prod": "ENVFILE=.env.production react-native run-android --mode ProductionDebug --appIdSuffix=production",
     "android:release:prod": "ENVFILE=.env.production react-native run-android --mode ProductionRelease --appIdSuffix=production",
     "android:qa:distribute": "bundle exec fastlane android qa_distribute",


### PR DESCRIPTION




## Description

Small refactor so debug builds can be built without `release.keystore` being present



## Things to check

Checklist:

- [ ] Two reviews
- [ ] Manually tested iOS
- [x] Manually tested Android
- [ ] (Optional) Updated the [Confluence docs](https://anddigitaltransformation.atlassian.net/wiki/spaces/ML/pages/4398940396/MCDBA+Mobile+App)
