### PR TITLE
fix: update macos runner to 15 to allow ios 18.2

### DIFF
--- a/.github/workflows/distribute-apps.yml
+++ b/.github/workflows/distribute-apps.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   distribute-ios:
-    runs-on: macos-14
+    runs-on: macos-15
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout Tag

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -59,7 +59,7 @@ jobs:
           echo "${{ steps.get-previous-release.outputs.previous_tag }}"
   prepare_for_release:
     needs: [tests, check_branch, get_version_number]
-    runs-on: macos-14
+    runs-on: macos-15
     environment: 'production'
     steps:
       - name: Checkout Tag


### PR DESCRIPTION
## Ticket name and link

#(634)

https://anddigitaltransformation.atlassian.net/jira/software/projects/MCDBA/boards/643?selectedIssue=MCDBA-418

## Description

macOS 14 runner doesnt support ios 18.2 simulators. Bump to macOS 15 to allow new iOS releases

## Things to check

Checklist:

- [ ] Two reviews
- [ ] Manually tested iOS
- [ ] Manually tested Android
- [ ] (Optional) Updated the [Confluence docs](https://anddigitaltransformation.atlassian.net/wiki/spaces/ML/pages/4398940396/MCDBA+Mobile+App)
