### PR TITLE
326 : Add Event Input Limit

### DIFF
--- a/src/components/atoms/InputField/InputField.tsx
+++ b/src/components/atoms/InputField/InputField.tsx
@@ -28,6 +28,7 @@ const InputField = ({text, setText, testID}: inputFieldProps) => {
           variant={'unstyled'}
           selectionColor={'brand.red'}
           testID={testID}
+          maxLength={256}
         />
       </ScrollView>
     </Box>


### PR DESCRIPTION
[#(326)](https://anddigitaltransformation.atlassian.net/jira/software/projects/MCDBA/boards/643?selectedIssue=MCDBA-326)

## Description

Add max length to input so cannot add more than 256 characters to input field, since rules concerning text length greater than 200 already in place for formatting.

## Things to check

Checklist:

- [ ] Two reviews
- [ ] Manually tested iOS
- [ ] Manually tested Android
- [ ] (Optional) Updated the [Confluence docs](https://anddigitaltransformation.atlassian.net/wiki/spaces/ML/pages/4398940396/MCDBA+Mobile+App)
